### PR TITLE
added simple tests for boundary_conditions

### DIFF
--- a/tests/test_boundary_conditions.py
+++ b/tests/test_boundary_conditions.py
@@ -1,0 +1,20 @@
+import pytest
+import numpy as np
+import sys 
+sys.path.insert(0, '../src')
+from boundary_conditions import boundary_conditions
+
+def test_bc_type():
+    
+    part_outer_rad = 10
+    boundary_temp = 1
+
+    assert type(boundary_conditions(part_outer_rad, boundary_temp))==list
+
+
+def test_bc():
+
+    part_outer_rad = 10
+    boundary_temp = 1
+
+    assert pytest.approx(boundary_conditions(part_outer_rad, boundary_temp),[part_outer_rad, boundary_temp])


### PR DESCRIPTION
I tried to make this a part of #53, but my pull request to @rarmstrong3's branch was too slow, @Zach-Fiscus already merged it

Here was the justification I had about adding these tests:

added two very simple tests. They are trivial at this point (checking the output type and basically redoing the whole function), but the idea is that if boundary_conditions ever becomes more complex, these tests would still be relevant and confirm that the function is doing what we want it to do