### PR TITLE
test material property library

### DIFF
--- a/src/test_material_properties.py
+++ b/src/test_material_properties.py
@@ -1,0 +1,11 @@
+from material_properties import material_property_library as mp
+import pytest
+
+
+def test_output_class():
+    A = {'UO2':{'rho':10.5, 'k':2.5, 'c':332}}
+    
+    assert isinstance(mp(A), dict)
+    
+    """The output of the function should be a dictionary"""
+    


### PR DESCRIPTION
This function contains argparse to deal with many potential user induced errors making it quite robust. Therefore, this contains just one test to simply test if the output is a dictionary.